### PR TITLE
Ra/logging bw compat

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 0.8.5 - ????-??-??
 ==================
 
+- Replaced `metlog.decorators.base.MetlogClientWrapper` with
+  `metlog.holder.MetlogClientHolder` which is a bit more useful and a bit more
+  sane.
+- Moved Python stdlib `logging` compatibility hooks into its own module.
+- Updated config parsing to support global values stored in the CLIENT_HOLDER.
+
 0.8.4 - 2012-04-18
 ==================
 

--- a/metlog/tests/test_config.py
+++ b/metlog/tests/test_config.py
@@ -93,6 +93,20 @@ def test_int_bool_conversions():
                                   false2=False, false3=False, false4=False)
 
 
+def test_global_config():
+    cfg_txt = """
+    [metlog]
+    sender_class = metlog.senders.DebugCaptureSender
+    global_foo = bar
+    global_multi = one
+                   two
+    """
+    client_from_text_config(cfg_txt, 'metlog')
+    from metlog.holder import CLIENT_HOLDER
+    expected = {'foo': 'bar', 'multi': ['one', 'two']}
+    eq_(expected, CLIENT_HOLDER.global_config)
+
+
 def test_filters_config():
     cfg_txt = """
     [metlog]


### PR DESCRIPTION
Added support for configuration of the metlog global config to be stored in the CLIENT_HOLDER.
