### PR TITLE
Vng/extended exceptions

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -144,8 +144,8 @@ parameters. Here's an example ::
 
 Once you obtain a reference to a client, you can access the new method. ::
 
-    from metlog.decorators.base import CLIENT_WRAPPER
-    client = CLIENT_WRAPPER.client
+    from metlog.holder import CLIENT_HOLDER
+    client = CLIENT_HOLDER.get_client('your_app_name')
     client.dummy('some', 'ignored', 'arguments', 42)
 
 

--- a/metlog/client.py
+++ b/metlog/client.py
@@ -203,15 +203,17 @@ class MetlogClient(object):
                 return
         self.sender.send_message(msg)
 
-    def add_method(self, name, method):
+    def add_method(self, name, method, override):
         """
         Add a custom method to the MetlogClient instance.
 
         :param name: Name to use for the method.
         :param method: Callable that will be used as the method.
+        :param override: Set this to True if you really want to
+                         override an existing method.
         """
         assert isinstance(method, types.FunctionType)
-        if hasattr(self, name):
+        if not override and hasattr(self, name):
             msg = "The name [%s] is already in use" % name
             raise SyntaxError(msg)
         self._dynamic_methods[name] = method

--- a/metlog/client.py
+++ b/metlog/client.py
@@ -142,9 +142,10 @@ class MetlogClient(object):
         """
         :param sender: A sender object used for actual message delivery.
         :param logger: Default `logger` value for all sent messages.
-                       This should be your application name and should
-                       not be modified for different instances of
-                       metlog within your the scope of your app.
+                       This is commonly set to be the name of the
+                       current application and is not modified for
+                       different instances of metlog within the
+                       scope of the same application.
         :param severity: Default `severity` value for all sent messages.
         :param disabled_timers: Sequence of string tokens identifying timers
                                 that should be deactivated.
@@ -203,7 +204,7 @@ class MetlogClient(object):
                 return
         self.sender.send_message(msg)
 
-    def add_method(self, name, method, override):
+    def add_method(self, name, method, override=False):
         """
         Add a custom method to the MetlogClient instance.
 
@@ -253,17 +254,13 @@ class MetlogClient(object):
         severity = severity if severity is not None else self.severity
         fields = fields if fields is not None else dict()
 
-        # Populate the pid and hostname into the fields dictionary
-        # with a metlog_ prefix so that we don't clobber any other
-        # data
-        fields['metlog_pid'] = self.pid
-        fields['metlog_hostname'] = self.hostname
-
         if hasattr(timestamp, 'isoformat'):
             timestamp = timestamp.isoformat()
         full_msg = dict(type=type, timestamp=timestamp, logger=logger,
                         severity=severity, payload=payload, fields=fields,
-                        env_version=self.env_version)
+                        env_version=self.env_version,
+                        metlog_pid=self.pid,
+                        metlog_hostname=self.hostname)
         self.send_message(full_msg)
 
     def timing(self, timer, elapsed):

--- a/metlog/client.py
+++ b/metlog/client.py
@@ -137,7 +137,7 @@ class MetlogClient(object):
     """
     env_version = '0.8'
 
-    def __init__(self, sender=None, logger='', severity=6,
+    def __init__(self, sender, logger, severity=6,
                  disabled_timers=None, filters=None):
         """
         :param sender: A sender object used for actual message delivery.

--- a/metlog/config.py
+++ b/metlog/config.py
@@ -174,9 +174,11 @@ def client_from_dict_config(config, client=None, clear_global=False):
 
     # Load plugins and pass in config
     for plugin_name, plugin_config in plugin_param.items():
-        config = plugin_config.pop('plugin.provider')
-        plugin = config(plugin_param[plugin_name])
-        client.add_method(plugin_name, plugin)
+        plugin_provider = plugin_config.pop('plugin.provider')
+        plugin_override = plugin_config.pop('override', False)
+
+        plugin = plugin_provider(plugin_param[plugin_name])
+        client.add_method(plugin_name, plugin, plugin_override)
 
     return client
 

--- a/metlog/holder.py
+++ b/metlog/holder.py
@@ -39,7 +39,9 @@ class MetlogClientHolder(object):
                 # check again to make sure nobody else got the lock first
                 client = self._clients.get(name)
                 if client is None:
-                    client = MetlogClient(logger=name)
+                    # TODO: there is no sender set here - grab one
+                    # based on the globalconfig
+                    client = MetlogClient(sender=None, logger=name)
                     if (not self._clients
                         and not self.global_config.get('default')):
                         # first one, set as default

--- a/metlog/tests/test_client.py
+++ b/metlog/tests/test_client.py
@@ -18,6 +18,8 @@ from mock import Mock
 from nose.tools import eq_, ok_
 from metlog.senders.dev import DebugCaptureSender
 
+import socket
+import os
 import threading
 import time
 
@@ -57,7 +59,8 @@ class TestMetlogClient(object):
         eq_(full_msg['type'], msgtype)
         eq_(full_msg['severity'], self.client.severity)
         eq_(full_msg['logger'], self.logger)
-        eq_(full_msg['fields'], dict())
+        eq_(full_msg['fields'], {'metlog_pid': os.getpid(),
+            'metlog_hostname': socket.gethostname()})
         eq_(full_msg['env_version'], self.client.env_version)
 
     def test_metlog_full(self):

--- a/metlog/tests/test_client.py
+++ b/metlog/tests/test_client.py
@@ -59,8 +59,8 @@ class TestMetlogClient(object):
         eq_(full_msg['type'], msgtype)
         eq_(full_msg['severity'], self.client.severity)
         eq_(full_msg['logger'], self.logger)
-        eq_(full_msg['fields'], {'metlog_pid': os.getpid(),
-            'metlog_hostname': socket.gethostname()})
+        eq_(full_msg['metlog_pid'], os.getpid())
+        eq_(full_msg['metlog_hostname'], socket.gethostname())
         eq_(full_msg['env_version'], self.client.env_version)
 
     def test_metlog_full(self):
@@ -72,11 +72,13 @@ class TestMetlogClient(object):
                                    'boo': 'far'})
         msgtype = 'bawlp'
         self.client.metlog(msgtype, **metlog_args)
-        full_msg = self._extract_full_msg()
+        actual_msg = self._extract_full_msg()
         metlog_args.update({'type': msgtype,
                             'env_version': self.client.env_version,
+                            'metlog_pid': os.getpid(),
+                            'metlog_hostname': socket.gethostname(),
                             'timestamp': metlog_args['timestamp'].isoformat()})
-        eq_(full_msg, metlog_args)
+        eq_(actual_msg, metlog_args)
 
     def test_timer_contextmanager(self):
         name = 'test'

--- a/metlog/tests/test_config.py
+++ b/metlog/tests/test_config.py
@@ -216,3 +216,23 @@ def test_handshake_sender_with_backend():
             eq_(mock_pool.send.call_count, 1)
             call_args = mock_pool.send.call_args[0]
             eq_(call_args[0], expected)
+
+def test_plugin_override():
+    cfg_txt = """
+    [metlog]
+    sender_class = metlog.senders.DebugCaptureSender
+    [metlog_plugin_exception]
+    override=True
+    provider=metlog.tests.plugin:config_plugin
+    """
+    client = client_from_text_config(cfg_txt, 'metlog')
+    eq_('my_plugin', client.exception.__name__)
+
+    cfg_txt = """
+    [metlog]
+    sender_class = metlog.senders.DebugCaptureSender
+    [metlog_plugin_exception]
+    provider=metlog.tests.plugin:config_plugin
+    """
+    # Failure to set an override argument will throw an exception
+    assert_raises(SyntaxError, client_from_text_config, cfg_txt, 'metlog')

--- a/metlog/tests/test_decorators.py
+++ b/metlog/tests/test_decorators.py
@@ -12,6 +12,9 @@
 #   Rob Miller (rmiller@mozilla.com)
 #
 # ***** END LICENSE BLOCK *****
+import socket
+import os
+
 from metlog.config import client_from_dict_config
 from metlog.decorators import incr_count
 from metlog.decorators import timeit
@@ -94,9 +97,13 @@ class TestDecoratorArgs(DecoratorTestBase):
         eq_(len(msgs), 1)
 
         expected = {'severity': 2, 'timestamp': 0,
-                    'fields': {'name': 'qdo.foo'},
+                    'fields': {'name': 'qdo.foo',
+                        'metlog_hostname': socket.gethostname(),
+                        'metlog_pid': os.getpid(),
+                        },
                     'logger': 'somelogger', 'type': 'counter',
-                    'payload': '5', 'env_version': '0.8'}
+                    'payload': '5', 'env_version': '0.8',
+                    }
         eq_(msgs[0], expected)
 
     @raises(TypeError)
@@ -120,9 +127,13 @@ class TestDecoratorArgs(DecoratorTestBase):
 
         expected = {'severity': 5, 'timestamp': 8231,
                     'fields': {'anumber': 42, 'rate': 7,
-                               'name': 'qdo.timeit', 'atext': 'foo'},
+                               'name': 'qdo.timeit', 'atext': 'foo',
+                               'metlog_hostname': socket.gethostname(),
+                               'metlog_pid': os.getpid(),
+                               },
                     'logger': 'timeit_logger', 'type': 'timer',
-                    'payload': '0', 'env_version': '0.8'}
+                    'payload': '0', 'env_version': '0.8',
+                    }
         eq_(msgs[0], expected)
 
     @raises(TypeError)

--- a/metlog/tests/test_decorators.py
+++ b/metlog/tests/test_decorators.py
@@ -98,11 +98,11 @@ class TestDecoratorArgs(DecoratorTestBase):
 
         expected = {'severity': 2, 'timestamp': 0,
                     'fields': {'name': 'qdo.foo',
-                        'metlog_hostname': socket.gethostname(),
-                        'metlog_pid': os.getpid(),
                         },
                     'logger': 'somelogger', 'type': 'counter',
                     'payload': '5', 'env_version': '0.8',
+                    'metlog_hostname': socket.gethostname(),
+                    'metlog_pid': os.getpid(),
                     }
         eq_(msgs[0], expected)
 
@@ -128,11 +128,11 @@ class TestDecoratorArgs(DecoratorTestBase):
         expected = {'severity': 5, 'timestamp': 8231,
                     'fields': {'anumber': 42, 'rate': 7,
                                'name': 'qdo.timeit', 'atext': 'foo',
-                               'metlog_hostname': socket.gethostname(),
-                               'metlog_pid': os.getpid(),
                                },
                     'logger': 'timeit_logger', 'type': 'timer',
                     'payload': '0', 'env_version': '0.8',
+                    'metlog_hostname': socket.gethostname(),
+                    'metlog_pid': os.getpid(),
                     }
         eq_(msgs[0], expected)
 


### PR DESCRIPTION
this adds support for overloading the built in MetlogClient methods like .exception() with plugins.  the primary usecase right now is replacing the simple exception() or error() methods with a richer sentry plugin to capture detailed stack traces.

Made a minor sphinx doc fix updating a reference to CLIENT_WRAPPER to the new CLIENT_HOLDER

Also added metlog_hostname and metlog_pid entries into all fields so that we can track where a log came from
