### PR TITLE
Vng/incr.fix

### DIFF
--- a/metlog/client.py
+++ b/metlog/client.py
@@ -280,7 +280,7 @@ class MetlogClient(object):
                     payload, fields)
 
     def incr(self, name, count=1, timestamp=None, logger=None, severity=None,
-             fields=None):
+             fields=None, rate=1.0):
         """
         Sends an 'increment counter' message.
 
@@ -294,6 +294,7 @@ class MetlogClient(object):
         payload = str(count)
         fields = fields if fields is not None else dict()
         fields['name'] = name
+        fields['rate'] = rate
         self.metlog('counter', timestamp, logger, severity, payload, fields)
 
     # Standard Python logging API emulation

--- a/metlog/tests/test_client.py
+++ b/metlog/tests/test_client.py
@@ -124,10 +124,13 @@ class TestMetlogClient(object):
     def test_incr(self):
         name = 'incr'
         self.client.incr(name)
+
         full_msg = self._extract_full_msg()
         eq_(full_msg['type'], 'counter')
         eq_(full_msg['logger'], self.logger)
         eq_(full_msg['fields']['name'], name)
+        # You have to have a rate set here
+        eq_(full_msg['fields']['rate'], 1)
         eq_(full_msg['payload'], '1')
 
         self.client.incr(name, 10)

--- a/metlog/tests/test_decorators.py
+++ b/metlog/tests/test_decorators.py
@@ -98,6 +98,7 @@ class TestDecoratorArgs(DecoratorTestBase):
 
         expected = {'severity': 2, 'timestamp': 0,
                     'fields': {'name': 'qdo.foo',
+                        'rate': 1.0,
                         },
                     'logger': 'somelogger', 'type': 'counter',
                     'payload': '5', 'env_version': '0.8',


### PR DESCRIPTION
counter messages must include a rate with at least a default of 1.0 for statsd/graphite or else the events a rate of 0 is used and the event is effectively discarded. 
