### PR TITLE
Vng/named plugins

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -131,14 +131,16 @@ the name `provider`. This is a dotted name for a function which will be used to
 configure a plugin.  The return value for the provider is a configured method
 which will then be bound into the Metlog client.
 
-Each plugin extension method is bound in with the suffix that follows the
-`metlog_plugin_` prefix in the configuration section name.
+Each plugin extension method has a canonical name that is bound to the
+metlog client as a method name. The suffix that follows the
+`metlog_plugin_` prefix is used only to distinguish logical sections
+for each plugin within the configuration file.
 
 An example best demonstrates what can be expected.  To load the dummy plugin,
 you need a `metlog_plugin_dummy` section as well as some configuration
 parameters. Here's an example ::
 
-    [metlog_plugin_dummy]
+    [metlog_plugin_dummysection]
     provider=metlog.tests.plugin.config_plugin
     port=8080
     host=localhost

--- a/metlog/client.py
+++ b/metlog/client.py
@@ -185,16 +185,19 @@ class MetlogClient(object):
                 return
         self.sender.send_message(msg)
 
-    def add_method(self, name, method, override=False):
+    def add_method(self, method, override=False):
         """
         Add a custom method to the MetlogClient instance.
 
-        :param name: Name to use for the method.
         :param method: Callable that will be used as the method.
         :param override: Set this to True if you really want to
                          override an existing method.
         """
         assert isinstance(method, types.FunctionType)
+
+        # Obtain the metlog name directly from the method
+        name = method.metlog_name 
+
         if not override and hasattr(self, name):
             msg = "The name [%s] is already in use" % name
             raise SyntaxError(msg)

--- a/metlog/config.py
+++ b/metlog/config.py
@@ -187,12 +187,12 @@ def client_from_dict_config(config, client=None, clear_global=False):
         client.setup(sender, logger, severity, disabled_timers, filters)
 
     # initialize plugins and attach to client
-    for plugin_name, plugin_spec in plugins_data.items():
+    for ignored_plugin_name, plugin_spec in plugins_data.items():
         # each plugin spec is a 2-tuple: (dotted_name, cfg)
         plugin_config = plugin_spec[1]
         plugin_override = plugin_config.pop('override', False)
         plugin_fn = resolver.resolve(plugin_spec[0])(plugin_config)
-        client.add_method(plugin_name, plugin_fn, plugin_override)
+        client.add_method(plugin_fn, plugin_override)
 
     return client
 

--- a/metlog/tests/plugin_exception.py
+++ b/metlog/tests/plugin_exception.py
@@ -14,7 +14,7 @@ entry_points section.
 Each plugin is bound into the metlog client if and only if there is
 configuration for the plugin.
 """
-METLOG_PLUGIN_NAME = 'dummy'
+METLOG_PLUGIN_NAME = 'exception'
 
 def config_plugin(config_dict):
     # Normally, the config_dict is unwrapped to get

--- a/metlog/tests/test_config.py
+++ b/metlog/tests/test_config.py
@@ -231,18 +231,19 @@ def test_plugin_override():
     cfg_txt = """
     [metlog]
     sender_class = metlog.senders.DebugCaptureSender
+
     [metlog_plugin_exception]
     override=True
     provider=metlog.tests.plugin:config_plugin
     """
     client = client_from_text_config(cfg_txt, 'metlog')
-    eq_('my_plugin', client.exception.__name__)
+    eq_('dummy', client.dummy.metlog_name)
 
     cfg_txt = """
     [metlog]
     sender_class = metlog.senders.DebugCaptureSender
     [metlog_plugin_exception]
-    provider=metlog.tests.plugin:config_plugin
+    provider=metlog.tests.plugin_exception:config_plugin
     """
     # Failure to set an override argument will throw an exception
     assert_raises(SyntaxError, client_from_text_config, cfg_txt, 'metlog')


### PR DESCRIPTION
this changes the plugin system so that each plugin function must have a 'metlog_plugin' attribute.

The suffix of the configuration section name is no longer used.
