### PR TITLE
Don't apply string formatting if no args were given.

### DIFF
--- a/metlog/client.py
+++ b/metlog/client.py
@@ -313,7 +313,8 @@ class MetlogClient(object):
         if (len(args) == 1 and hasattr(args[0], 'keys')
             and hasattr(args[0], '__getitem__')):
             args = args[0]
-        msg = msg % args
+        if args:
+            msg = msg % args
         exc_info = kwargs.get('exc_info', False)
         if exc_info:
             if not isinstance(exc_info, tuple):


### PR DESCRIPTION
Currently if I call client.error(message) with no additional arguments, metlog will apply string formatting to the message.  This can cause an error if the message happens to contain a percent symbol or other formatting control char.

This patch copies the approach of the stdlib logging module, where formatting is only done if args were actually provided.
