### PR TITLE
(github issue 37) do a deep copy of the configuration dictionary

### DIFF
--- a/metlog/config.py
+++ b/metlog/config.py
@@ -154,7 +154,7 @@ def client_from_dict_config(config, client=None, clear_global=False):
     """
     # Make a deep copy of the configuration so that subsequent uses of
     # the config won't blow up
-    config = copy.deepcopy(nest_prefixes(config))
+    config = nest_prefixes(copy.deepcopy(config))
 
     sender_config = config.get('sender', {})
     logger = config.get('logger', '')

--- a/metlog/config.py
+++ b/metlog/config.py
@@ -17,6 +17,7 @@ from metlog.path import DottedNameResolver
 from textwrap import dedent
 import ConfigParser
 import StringIO
+import copy
 import os
 import re
 
@@ -151,7 +152,9 @@ def client_from_dict_config(config, client=None, clear_global=False):
       All remaining key-value pairs in the sender config dict will be passed as
       keyword arguments to the sender constructor.
     """
-    config = nest_prefixes(config)
+    # Make a deep copy of the configuration so that subsequent uses of
+    # the config won't blow up
+    config = copy.deepcopy(nest_prefixes(config))
 
     sender_config = config.get('sender', {})
     logger = config.get('logger', '')

--- a/metlog/tests/test_config.py
+++ b/metlog/tests/test_config.py
@@ -14,6 +14,7 @@
 from metlog.exceptions import EnvironmentNotFoundError
 from metlog.client import MetlogClient
 from metlog.config import client_from_text_config
+from metlog.config import client_from_dict_config
 from metlog.senders import DebugCaptureSender
 from mock import Mock
 from mock import patch
@@ -227,6 +228,7 @@ def test_handshake_sender_with_backend():
             call_args = mock_pool.send.call_args[0]
             eq_(call_args[0], expected)
 
+
 def test_plugin_override():
     cfg_txt = """
     [metlog]
@@ -247,3 +249,13 @@ def test_plugin_override():
     """
     # Failure to set an override argument will throw an exception
     assert_raises(SyntaxError, client_from_text_config, cfg_txt, 'metlog')
+
+
+def test_load_config_multiple_times():
+    cfg = {'logger': 'addons-marketplace-dev',
+           'sender': {'class': 'metlog.senders.UdpSender',
+           'host': ['logstash1', 'logstash2'],
+           'port': '5566'}}
+
+    client_from_dict_config(cfg)
+    client_from_dict_config(cfg)


### PR DESCRIPTION
This prevents mutatation of the configuration so that subsequent uses
of the dictionary do not fail
